### PR TITLE
fix: fix destroy() not to throw an exception when the session does no…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,10 @@ export default class CosmosStore extends Store {
       await this.container.item(sid, sid).delete();
       callback(null);
     } catch (error) {
+      // Do not throw an exception if the session does not exist.
+      if ((error as { code: number })?.code === 404) {
+        return callback(null);
+      }
       callback(error);
     }
   }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -177,6 +177,14 @@ describe('Cosmos Store - Operations', () => {
     });
   });
 
+  it('should not throw errors when it destroy sessions', async () => {
+    const cosmosStore = await CosmosStore.initializeStore(options);
+    const [sessionId] = generateRandomSession();
+
+    // Destroy the session
+    await cosmosStore.destroy(sessionId);
+  });
+
   it('should return all the sessions and the count of sessions in the container', async () => {
     const cosmosStore = await CosmosStore.initializeStore(options);
     for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

When the login is invoked, req.session.regenerate() is called, which also calls destroy().
However, the first login raised an error because the session did not exist.
This PR prevents the error even if the session does not exist.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
